### PR TITLE
Draft text for recharter

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -12,7 +12,7 @@ The MASQUE working group is now in the process of completing its remaining deliv
  4. An extension to CONNECT-IP that allows conveying DNS and PREF64 configuration
  5. An informational architecture document about MASQUE
  6. An extension to CONNECT-UDP for ECN and DSCP support
- 7. An extensions to CONNECT-UDP and / or CONNECT-IP to enable compression
+ 7. An extension to CONNECT-UDP and / or CONNECT-IP to enable compression
  8. A definition of qlog nomenclature for existing MASQUE mechanisms
 
 These documents are being finished in line with MASQUE’s previous charter: 

--- a/charter.md
+++ b/charter.md
@@ -1,47 +1,31 @@
 # MASQUE Charter
 
-Many network topologies lead to situations where transport protocol proxying is beneficial. For example, proxying
-enables endpoints to communicate when end-to-end connectivity is not possible or to apply additional encryption where
-desirable (such as a VPN). Proxying can also improve client privacy, e.g., by hiding a client's IP address from a
-target server. Proxying technologies such as SOCKS and HTTP(S) CONNECT exist, albeit with their own shortcomings. For
-example, SOCKS signalling is not encrypted and HTTP CONNECT is currently limited to TCP.
+Many network topologies lead to situations where transport protocol proxying is beneficial—for example, enabling endpoints to communicate when end-to-end connectivity is not possible, or applying additional encryption such as in VPNs. Proxying can also improve client privacy by hiding client IP addresses from target servers. Existing proxying technologies (e.g., SOCKS and HTTP CONNECT) have limitations: SOCKS lacks encryption, and HTTP CONNECT is limited to TCP.
 
-The primary goal of this working group is to develop mechanism(s) that allow configuring and concurrently running
-multiple proxied stream- and datagram-based flows inside an HTTP connection. The group has specified CONNECT-UDP and
-CONNECT-IP, collectively known as MASQUE, to enable this functionality. MASQUE leverages the HTTP request/response
-semantics, multiplexes flows over streams, uses a unified congestion controller, encrypts flow metadata, and enables
-unreliable delivery suitable for UDP and IP-based applications.
+The MASQUE working group has developed mechanisms that allow configuring and concurrently running multiple proxied stream- and datagram-based flows inside an HTTP connection. These include CONNECT-UDP and CONNECT-IP, collectively known as MASQUE. MASQUE leverages HTTP semantics, multiplexes flows over streams, uses a unified congestion controller, encrypts flow metadata, and enables unreliable delivery suitable for UDP and IP-based applications.
 
-The MASQUE working group will now develop HTTP and/or HTTP/3 extensions to the core client-initiated CONNECT-UDP and
-CONNECT-IP functionality. Services that a proxy initiates without any prompt from a client are out of scope.
+The MASQUE working group is now in the process of completing its remaining deliverables:
 
-Exercising the extension points defined by CONNECT-UDP and CONNECT-IP helps to make it easier to support new use cases
-or accommodate changes in the environment in which these protocols are deployed. The initial set of extensions will be
-in support of UDP listening and QUIC-aware proxying. Additional extensions that provide missing functionality, improve
-performance, or otherwise ease deployability for use cases may be adopted where there are multiple implementation
-and/or deployment proponents. 
+ 1. A mechanism for proxying Ethernet over HTTP
+ 2. An extension to CONNECT-UDP that is specific to proxying QUIC
+ 3. An extension to CONNECT-UDP that allows proxying bound sockets
+ 4. An extension to CONNECT-IP that allows conveying DNS and PREF64 configuration
+ 5. An informational architecture document about MASQUE
+ 6. An extension to CONNECT-UDP for ECN and DSCP support
+ 7. An extensions to CONNECT-UDP and / or CONNECT-IP to enable compression
+ 8. A definition of qlog nomenclature for existing MASQUE mechanisms
 
-Extensions to HTTP Datagrams will be coordinated with HTTPBIS. Extensions that solely relate to generic proxying
-functionality, and are not specific to the core MASQUE documents, are out of scope. 
+These documents are being finished in line with MASQUE’s previous charter: 
 
-Specifying proxy server discovery mechanisms is out of scope. New congestion control and loss recovery algorithms are
-also out of scope. However, the working group will consider implications of tunneling protocols with congestion control
-and loss recovery over MASQUE proxies, and may issue recommendations accordingly. 
+* The intended status is Standards Track unless otherwise noted, but the WG may downgrade if it believes that is appropriate for the ultimate document maturity level.
+* Services that a proxy initiates without any prompt from a client are out of scope.
+* Extensions that solely relate to generic proxying functionality, and are not specific to the core MASQUE documents, are out of scope.
+* Specifying proxy server discovery mechanisms is out of scope. New congestion control and loss recovery algorithms are also out of scope. However, the working group will consider implications of tunneling protocols with congestion control and loss recovery over MASQUE proxies, and may issue recommendations accordingly.
+* IP multicast is out of scope. Designs need not explicitly preclude multicast, but they will not focus on multicast-specific features.
+* Impacts on address migration, NAT rebinding, and future multipath mechanisms of QUIC are not anticipated. However, the working group should document these impacts, or those of any other QUIC developments, if they arise.
 
-The working group will consider how the protocols it defines might operate over versions of HTTP that use TCP rather
-than QUIC, for use when QUIC is unavailable. This might include defining alternative extensions specifically for use in
-these HTTP versions.
+Beyond finalizing these documents, the MASQUE working group is not accepting new work items. Any proposals for new extensions or functionality should be directed to appropriate alternative working groups such as HTTPBIS, QUIC, or INTAREA, depending on the nature of the work.
 
-IP multicast is out of scope. Extensions providing generic capabilities that might include IP multicast are acceptable
-on the basis of their application to other use cases. For example, a generic IP proxy might be used for both unicast
-and multicast communication. For such generic capabilities, designs will not explicitly preclude multicast, but they
-will not focus on multicast-specific features.
+MASQUE will continue to coordinate closely with HTTPBIS, QUIC, TLS, INTAREA, ICCRG, CCWG, and IEEE 802.3 as appropriate.
 
-Impacts on address migration, NAT rebinding, and future multipath mechanisms of QUIC are not anticipated. However, the
-working group should document these impacts, or those of any other QUIC developments, if they arise.
-
-The group will coordinate closely with other working groups responsible for maintaining relevant protocol extensions,
-such as HTTPBIS, QUIC, or TLS. It will also coordinate closely with ICCRG and TSVWG on congestion control and loss
-recovery considerations, and intarea for IP Proxying.
-
-When these deliverables are complete, the working group will either recharter to reflect additional work or close.
+The MASQUE working group is expected to conclude once its current documents are published.


### PR DESCRIPTION
This is some proposed text for rechartering Masque to bring [draft-schinazi-masque-proxy](https://datatracker.ietf.org/doc/draft-schinazi-masque-proxy/) within scope and begin sunsetting the WG. 

The charter keeps the existing WG documents within scope: 

| Draft | Status |
| ------------- | ------------- |
| [draft-ietf-masque-connect-ethernet](https://datatracker.ietf.org/doc/draft-ietf-masque-connect-ethernet/)  | Ready for submission to IESG |
| [draft-ietf-masque-connect-udp-listen ](https://datatracker.ietf.org/doc/draft-ietf-masque-connect-udp-listen/)| Ready for submission to IESG  |
| [draft-ietf-masque-quic-proxy](https://datatracker.ietf.org/doc/draft-ietf-masque-quic-proxy/) | Ready for submission to IESG | 
| [draft-ietf-masque-connect-ip-dns](https://datatracker.ietf.org/doc/draft-ietf-masque-connect-ip-dns/) | Nearing WGLC | 

The charter also enumerates the recently proposed work as in scope: 

* An informational architecture document about MASQUE, e.g.
  * [draft-schinazi-masque-proxy](https://datatracker.ietf.org/doc/draft-schinazi-masque-proxy/).
* An extension to CONNECT-UDP for ECN and DSCP support, e.g.
  * [draft-westerlund-masque-connect-udp-ecn-dscp](https://datatracker.ietf.org/doc/draft-westerlund-masque-connect-udp-ecn-dscp/)
  * [draft-seemann-masque-connect-udp-ecn](https://datatracker.ietf.org/doc/draft-seemann-masque-connect-udp-ecn/)
* An extensions to CONNECT-UDP and / or CONNECT-IP to enable compression, e.g.
  * [draft-kuehlewind-masque-ip-compression](https://datatracker.ietf.org/doc/draft-kuehlewind-masque-ip-compression/)
  * [draft-rosomakho-masque-connect-ip-optimizations](https://datatracker.ietf.org/doc/draft-rosomakho-masque-connect-ip-optimizations/)
* A definition of qlog nomenclature for existing MASQUE mechanisms. 
  * No one has put a draft forward, but interest has been expressed from multiple participants. 
